### PR TITLE
update pebble with profile support and short times for CI testing of …

### DIFF
--- a/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
+++ b/certbot-ci/certbot_integration_tests/utils/pebble_artifacts.py
@@ -69,6 +69,16 @@ def _build_pebble_config(workspace: str, http_01_port: int, assets_path: str) ->
                 'httpPort': http_01_port,
                 'tlsPort': 5001,
                 'ocspResponderURL': 'http://127.0.0.1:{0}'.format(MOCK_OCSP_SERVER_PORT),
+                'profiles': {
+                    'default': {
+                        'description': 'The profile you know and love',
+                        'validityPeriod': 10,
+                    },
+                    'shortlived': {
+                        'description': 'A short-lived cert profile, without actual enforcement',
+                        'validityPeriod': 5,
+                    },
+                },
             },
         }))
 


### PR DESCRIPTION
I saw your comment about ARI in pebble for CI testing; on my system I dropped the config time down to 10s normal and 5s shortlived.  that WILL allow for ARI testing in the future.

the current pebble logic does not support ARI for certs that expire within the next 2 days; i have a PR under review to fix that and test with a fork.